### PR TITLE
Fixed loop-ending order

### DIFF
--- a/pig.py
+++ b/pig.py
@@ -20,9 +20,9 @@ while not done:
         roll = random.randint(1,6)
         print("You rolled a", roll)
         if roll == 1:
-            turn = "computer"
             player_temp_total = 0
             print("PIG! Too bad! Your total is currently:", player_total)
+            turn = "computer"
         else:
             player_temp_total += roll
             print("You currently have " + str(player_temp_total) + " banked.")
@@ -30,7 +30,7 @@ while not done:
             if choice == 'n':
                 player_total += player_temp_total
                 player_temp_total = 0
-                print("Your total socre is now:", player_total)
+                print("Your total score is now:", player_total)
                 turn = "computer"
         if player_total > winning_score:
             print("You win! " + str(player_total) + " to " + str(comp_total))
@@ -43,9 +43,9 @@ while not done:
         roll = random.randint(1,6)
         print("The computer rolled a", roll)
         if roll == 1:
-            turn = "player"
             comp_temp_total = 0
             print("PIG! Too bad! The computer's total is currently:", comp_total)
+            turn = "player"
         else:
             comp_temp_total += roll
             print("The computer has " + str(comp_temp_total) + " banked.")


### PR DESCRIPTION
Made it so when you roll a 1, the turn changes to the next player AFTER the bank is reset and the string is printed so as to avoid any possibility of the loop ending too early.